### PR TITLE
Fix read port for mongo version 4.4

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefaultOptions(t *testing.T) {
-	versions := []string{"3.2.22", "3.4.21", "3.6.13", "4.0.13", "4.2.1"}
+	versions := []string{"3.2.22", "3.4.21", "3.6.13", "4.0.13", "4.2.1", "4.4.11"}
 
 	for _, version := range versions {
 		t.Run(version, func(t *testing.T) {


### PR DESCRIPTION
<!--- Strike PULL_REQUEST_TEMPLATE File -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mongo version 4.4 log format is changed. This reason port number cannot read in log.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<!--- Please remove this section if not needed in your project -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.