### PR TITLE
fix: set default timeout

### DIFF
--- a/config.go
+++ b/config.go
@@ -113,9 +113,10 @@ func (opts *Options) fillDefaults() error {
 
 		opts.Port = port
 
-		if opts.StartupTimeout == 0 {
-			opts.StartupTimeout = 10 * time.Second
-		}
+	}
+
+	if opts.StartupTimeout == 0 {
+		opts.StartupTimeout = 10 * time.Second
 	}
 
 	return nil


### PR DESCRIPTION
<!--- Strike PULL_REQUEST_TEMPLATE File -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Timeout was not set by default if no port was provided. It looks like there was a mixup in the code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a default timeout setting of 10 seconds, though it is only set if the port is provided in the options as well. These settings should be independent, so a default timeout should also be set for a random port.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual test. I don't see side effects for the rest of the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.