### PR TITLE
Enable strikememmongo to be used with latest mongodb versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/strikesecurity/strikememongo
+module github.com/rameshsunkara/strikememongo
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func (s *Server) Stop() {
 }
 
 // Cribbed from https://github.com/nodkz/mongodb-memory-server/blob/master/packages/mongodb-memory-server-core/src/util/MongoInstance.ts#L206
-var reReady = regexp.MustCompile(`waiting for connections on port (\d+)`)
+var reReady = regexp.MustCompile(`waiting for connections.*port(\s|":)(\d+)`)
 var reAlreadyInUse = regexp.MustCompile("addr already in use")
 var reAlreadyRunning = regexp.MustCompile("mongod already running")
 var rePermissionDenied = regexp.MustCompile("mongod permission denied")
@@ -243,7 +243,7 @@ func stdoutHandler(log *strikememongolog.Logger) (io.Writer, <-chan error, <-cha
 				downcaseLine := strings.ToLower(line)
 
 				if match := reReady.FindStringSubmatch(downcaseLine); match != nil {
-					port, err := strconv.Atoi(match[1])
+					port, err := strconv.Atoi(match[2])
 					if err != nil {
 						errChan <- errors.New("Could not parse port from mongod log line: " + downcaseLine)
 					} else {

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefaultOptions(t *testing.T) {
-	versions := []string{"3.2.22", "3.4.21", "3.6.13", "4.0.13", "4.2.1"}
+	versions := []string{"3.2.22", "3.4.21", "3.6.13", "4.0.13", "4.2.1", "6.0.3"}
 
 	for _, version := range versions {
 		t.Run(version, func(t *testing.T) {


### PR DESCRIPTION
<!--- Strike PULL_REQUEST_TEMPLATE File -->

Update regex to detect latest mongodb (6.X) readyness

<!--- Provide a general summary of your changes in the Title above -->

## Description
Latest version of mongodb i.e., 6.X not only uses structured logging, it also slightly changed the log message.
So strikememmongo was unable to detect the readyness of mongodb and hence failing to initialize connection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to use strikememmongo with latest version of mongodb as we use latest version in our project and it didn't worked when I just passed latest version. So I debugged and ended up finding the problem.

With my fix, it can now be used with latest versions of MongoDB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, I updated the unit tests and ran them in my local before submitting this PR.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.